### PR TITLE
Add apps.yaml entry for fission functions

### DIFF
--- a/clusters/staging/davidepa/apps.yaml
+++ b/clusters/staging/davidepa/apps.yaml
@@ -130,3 +130,23 @@ spec:
             jsonPointers:
               - /rules
     {{- end }}
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: fission-functions
+  namespace: argocd
+spec:
+  destination:
+    namespace: fission
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    repoURL: "https://github.com/DaveWox/fission-functions.git"
+    targetRevision: main
+    path: fission/overlays/cluster
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
Added a new application entry for the fission functions in the staging cluster. This will allow us to deploy and manage our serverless functions using Fission. The source points to the fission-functions repository at DaveWox/fission-functions.

