### PR TITLE
added additional namespaces to fission values.yaml

### DIFF
--- a/clusters/staging/davidepa/fission-values.yaml
+++ b/clusters/staging/davidepa/fission-values.yaml
@@ -3,6 +3,8 @@ stfc-cloud-fission:
     openTelemetry:
       otlpCollectorEndpoint: "otel-collector.opentelemetry-operator-system.svc:4317"
 
+    additionalFissionNamespaces: [fission]
+
     serviceMonitor:
       enabled: true
       namespace: "monitoring-system"


### PR DESCRIPTION
added the fission namespace to the additionalFissionNamespaces list in the fission-values.yaml file. This allows for the monitoring of fission resources in the specified namespace in addition to the default one.


