### PR TITLE
added annotations to ignore fission preupgrade

### DIFF
--- a/clusters/staging/davidepa/apps.yaml
+++ b/clusters/staging/davidepa/apps.yaml
@@ -83,6 +83,16 @@ spec:
     metadata:
       name: "{{.name}}"
       namespace: argocd
+      annotations:
+        argocd.argoproj.io/ignore-resources: |
+          group: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: fission-preupgrade
+          group: rbac.authorization.k8s.io
+          kind: Role
+          name: fission-preupgrade-fission-cr
+          namespace: fission
+
     spec:
       project: default
       source:

--- a/clusters/staging/davidepa/fission-values.yaml
+++ b/clusters/staging/davidepa/fission-values.yaml
@@ -3,6 +3,8 @@ stfc-cloud-fission:
     openTelemetry:
       otlpCollectorEndpoint: "otel-collector.opentelemetry-operator-system.svc:4317"
 
+    additionalFissionNamespaces: [fission]
+
     serviceMonitor:
       enabled: true
       namespace: "monitoring-system"


### PR DESCRIPTION
added annotations to ignore fission preupgrade roles in argocd apps.yaml in order to prevent argocd from trying to manage those resources which are created by fission preupgrade job and are not meant to be managed by argocd. This is necessary to avoid conflicts and errors during the deployment process.