### PR TITLE
Added template patch for fission

### DIFF
--- a/clusters/staging/davidepa/apps.yaml
+++ b/clusters/staging/davidepa/apps.yaml
@@ -83,15 +83,6 @@ spec:
     metadata:
       name: "{{.name}}"
       namespace: argocd
-      annotations:
-        argocd.argoproj.io/ignore-resources: |
-          group: rbac.authorization.k8s.io
-          kind: ClusterRole
-          name: fission-preupgrade
-          group: rbac.authorization.k8s.io
-          kind: Role
-          name: fission-preupgrade-fission-cr
-          namespace: fission
 
     spec:
       project: default
@@ -140,6 +131,15 @@ spec:
             jsonPointers:
               - /rules
     {{- end }}
+
+    
+    {{- if eq .name "fission" }}
+        spec:
+          source:
+            helm:
+              skipHooks: true
+      {{- end }
+
 
 ---
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
Removed the annotations that were added to the fission application in apps.yaml and added a templatepatch to skip hooks for fission. This is to try to resolve an issue where the sync is failing as the preupgrade hook is trying to create a resource that already exists.

