### PR TITLE
Correct syntax error in templatePatch

### DIFF
--- a/clusters/staging/davidepa/apps.yaml
+++ b/clusters/staging/davidepa/apps.yaml
@@ -138,7 +138,7 @@ spec:
           source:
             helm:
               skipHooks: true
-      {{- end }
+    {{- end }}
 
 
 ---


### PR DESCRIPTION
Corrected simple syntax error in the template patch for fission.

