### PR TITLE
Set fission to use cert manager for webhook certs

### DIFF
--- a/clusters/staging/davidepa/apps.yaml
+++ b/clusters/staging/davidepa/apps.yaml
@@ -133,12 +133,22 @@ spec:
     {{- end }}
 
     
-    {{- if eq .name "fission" }}
-        spec:
-          source:
-            helm:
-              skipHooks: true
-    {{- end }}
+    {{- if eq .name "cert-manager" }}
+      metadata:
+        annotations:
+          argocd.argoproj.io/sync-wave: "0"
+      {{- end }}
+
+      {{- if eq .name "fission" }}
+      metadata:
+        annotations:
+          argocd.argoproj.io/sync-wave: "1"
+      spec:
+        source:
+          helm:
+            skipHooks: true        # You already added this
+      {{- end }}
+
 
 
 ---

--- a/clusters/staging/davidepa/fission-values.yaml
+++ b/clusters/staging/davidepa/fission-values.yaml
@@ -4,6 +4,10 @@ stfc-cloud-fission:
       otlpCollectorEndpoint: "otel-collector.opentelemetry-operator-system.svc:4317"
 
     additionalFissionNamespaces: [fission]
+    
+    webhook:
+      certManager:
+        enabled: true
 
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
Set fission to use cert manager for webhook certificates. Also added sync waves to the apps.yaml to ensure that cert manager is installed before fission.

