### PR TITLE
Added routerServiceType: ClusterIP

### DIFF
--- a/clusters/staging/davidepa/fission-values.yaml
+++ b/clusters/staging/davidepa/fission-values.yaml
@@ -1,5 +1,7 @@
 stfc-cloud-fission:
   fission-all:
+    routerServiceType: ClusterIP
+    
     openTelemetry:
       otlpCollectorEndpoint: "otel-collector.opentelemetry-operator-system.svc:4317"
 


### PR DESCRIPTION
Added routerServiceType: ClusterIP to fission-values.yaml to change the service type of the Fission router to ClusterIP. This will allow the router to be accessed only within the cluster, improving security and reducing exposure to external traffic. External traffic will be handled by an ingress controller.


